### PR TITLE
fixed Calculator.sphVol method

### DIFF
--- a/Calculator.java
+++ b/Calculator.java
@@ -142,6 +142,6 @@ public class Calculator {
 	 * @return the volume of a sphere with radius r.
 	 */
 	public double sphVol(double r) {
-		return 2 * Math.PI * r;
+		return (4.0/3.0) * Math.PI * Math.pow(r,3);
 	}
 }


### PR DESCRIPTION
This commit fixes the bug #11 (sphVol() method). Previously the method was computing the circumference, this commit changes it to correctly calculate the volume of a sphere with radius r.